### PR TITLE
Initialize pluma device only after it started

### DIFF
--- a/Workflows/ExperimentAcquisition.bonsai
+++ b/Workflows/ExperimentAcquisition.bonsai
@@ -1238,10 +1238,8 @@
                           <Name>HarpSoftwareLogging</Name>
                         </Expression>
                         <Expression xsi:type="WorkflowOutput" />
-                        <Expression xsi:type="Combinator">
-                          <Combinator xsi:type="IntProperty">
-                            <Value>0</Value>
-                          </Combinator>
+                        <Expression xsi:type="SubscribeSubject">
+                          <Name>PlumaEvents</Name>
                         </Expression>
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="rx:Take">


### PR DESCRIPTION
This PR only initializes pluma board after receive one event from it.
