### PR TITLE
Update AlfamaVR to support Unity recordings while running acquisition workflow in bonsai

### DIFF
--- a/VR-Alfama/Assets/Scenes/VR-Alfama.unity
+++ b/VR-Alfama/Assets/Scenes/VR-Alfama.unity
@@ -1333,9 +1333,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 938518b1a2fa4ba42aa0a71acc8bf260, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  BasePath: C:\Data\VideosData
-  Filename: exp1
-  SubscriberAddress: 
+  PublisherBindAddress: tcp://localhost:5561
+  BasePath: C:\Data\VideosData\
+  Filename: VrVideo
+  SubscriberAddress: tcp://localhost:5560
   StartRecordingKey: 32
   StopRecordingKey: 304
 --- !u!1 &681729591
@@ -2730,6 +2731,24 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 3827635044414375890, guid: 22732481f23aec646baef4459a695737, type: 3}
+--- !u!1 &1784282895 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6711714439356026094, guid: 573ac53c334415945bf239de2c2f0511, type: 3}
+  m_PrefabInstance: {fileID: 1448742964}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1784282905
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1784282895}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1479fe22bfe856b4197bdcd756b9b8b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  PublisherBindAddress: tcp://localhost:5558
 --- !u!1 &1799948686 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4237835407467653916, guid: 22732481f23aec646baef4459a695737, type: 3}

--- a/Workflows/ExperimentAcquisitionVR.bonsai
+++ b/Workflows/ExperimentAcquisitionVR.bonsai
@@ -7,10 +7,9 @@
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                  xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
-                 xmlns:p2="clr-namespace:OpenCV.Net;assembly=OpenCV.Net"
-                 xmlns:ubx="clr-namespace:EmotionalCities.uBlox;assembly=EmotionalCities.uBlox"
                  xmlns:lsl="clr-namespace:EmotionalCities.Lsl;assembly=EmotionalCities.Lsl"
-                 xmlns:p3="clr-namespace:NetMQ;assembly=NetMQ"
+                 xmlns:p2="clr-namespace:NetMQ;assembly=NetMQ"
+                 xmlns:p3="clr-namespace:OpenCV.Net;assembly=OpenCV.Net"
                  xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
                  xmlns:zmq="clr-namespace:Bonsai.ZeroMQ;assembly=Bonsai.ZeroMQ"
                  xmlns:pluma="clr-namespace:EmotionalCities.Pluma;assembly=EmotionalCities.Pluma"
@@ -145,22 +144,12 @@
             <Expression xsi:type="IncludeWorkflow" Path="Extensions\LogHarpReadDump.bonsai">
               <LogName>StreamReadDump.bin</LogName>
             </Expression>
-            <Expression xsi:type="rx:BehaviorSubject" TypeArguments="p2:Mat">
-              <rx:Name>MicrophoneData</rx:Name>
-            </Expression>
-            <Expression xsi:type="IncludeWorkflow" Path="Extensions\LogMicrophone.bonsai">
-              <LogName>Microphone.bin</LogName>
-            </Expression>
             <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Tuple(p1:AccelerometerData,sys:Double,sys:Double)">
               <rx:Name>AccelerometerData</rx:Name>
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="Extensions\LogAccelerometer.bonsai">
               <LogName>Accelerometer.csv</LogName>
             </Expression>
-            <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Tuple(ubx:UbxPacket,sys:Double)">
-              <rx:Name>UbxEvents</rx:Name>
-            </Expression>
-            <Expression xsi:type="IncludeWorkflow" Path="Extensions\LogUBX.bonsai" />
             <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Tuple(sys:String,sys:Double)">
               <rx:Name>EmpaticaEvents</rx:Name>
             </Expression>
@@ -173,176 +162,7 @@
             <Expression xsi:type="IncludeWorkflow" Path="Extensions\LogEegMarkers.bonsai">
               <LogName>eeg_markers.csv</LogName>
             </Expression>
-            <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Tuple(harp:Timestamped(sys:Int32),p3:NetMQMessage,sys:String)">
-              <rx:Name>PupilSensorLogging</rx:Name>
-            </Expression>
-            <Expression xsi:type="IncludeWorkflow" Path="Extensions\LogPupilSensor.bonsai" />
-            <Expression xsi:type="rx:BehaviorSubject" TypeArguments="harp:Timestamped(p2:IplImage)">
-              <rx:Name>PupilDecodedFrames</rx:Name>
-            </Expression>
-            <Expression xsi:type="scr:ExpressionTransform">
-              <scr:Expression>it.Value != null ? 1 : 0</scr:Expression>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>Seconds</Selector>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Zip" />
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="harp:CreateTimestamped" />
-            </Expression>
-            <Expression xsi:type="harp:Format">
-              <harp:MessageType>Event</harp:MessageType>
-              <harp:Register xsi:type="harp:FormatMessagePayload">
-                <harp:Address>209</harp:Address>
-                <harp:PayloadType>TimestampedU64</harp:PayloadType>
-              </harp:Register>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>HarpSoftwareLogging</Name>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>PupilDecodedFrames</Name>
-            </Expression>
-            <Expression xsi:type="rx:Condition">
-              <Name>DropNull</Name>
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="WorkflowInput">
-                    <Name>Source1</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>Value</Selector>
-                  </Expression>
-                  <Expression xsi:type="scr:ExpressionTransform">
-                    <scr:Expression>it == null</scr:Expression>
-                  </Expression>
-                  <Expression xsi:type="BitwiseNot" />
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="1" Label="Source1" />
-                  <Edge From="1" To="2" Label="Source1" />
-                  <Edge From="2" To="3" Label="Source1" />
-                  <Edge From="3" To="4" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>Value</Selector>
-            </Expression>
-            <Expression xsi:type="GroupWorkflow">
-              <Name>LogVideo</Name>
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="WorkflowInput">
-                    <Name>Source1</Name>
-                  </Expression>
-                  <Expression xsi:type="SubscribeSubject">
-                    <Name>LoggingPath</Name>
-                  </Expression>
-                  <Expression xsi:type="ExternalizedMapping">
-                    <Property Name="Value" DisplayName="LogName" />
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="StringProperty">
-                      <Value>pupil_video.avi</Value>
-                    </Combinator>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="rx:Zip" />
-                  </Expression>
-                  <Expression xsi:type="Format">
-                    <Format>{0}\{1}</Format>
-                    <Selector>Item1,Item2</Selector>
-                  </Expression>
-                  <Expression xsi:type="PropertyMapping">
-                    <PropertyMappings>
-                      <Property Name="FileName" />
-                    </PropertyMappings>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="cv:VideoWriter">
-                      <cv:FileName>C:\IndoorData\NGR_LAB_sub-01_2023-10-12T164616Z\\pupil_video.avi</cv:FileName>
-                      <cv:Suffix>None</cv:Suffix>
-                      <cv:Buffered>true</cv:Buffered>
-                      <cv:Overwrite>false</cv:Overwrite>
-                      <cv:FourCC>FMP4</cv:FourCC>
-                      <cv:FrameRate>30</cv:FrameRate>
-                      <cv:FrameSize>
-                        <cv:Width>0</cv:Width>
-                        <cv:Height>0</cv:Height>
-                      </cv:FrameSize>
-                      <cv:ResizeInterpolation>NearestNeighbor</cv:ResizeInterpolation>
-                    </Combinator>
-                  </Expression>
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="7" Label="Source1" />
-                  <Edge From="1" To="4" Label="Source1" />
-                  <Edge From="2" To="3" Label="Source1" />
-                  <Edge From="3" To="4" Label="Source2" />
-                  <Edge From="4" To="5" Label="Source1" />
-                  <Edge From="5" To="6" Label="Source1" />
-                  <Edge From="6" To="7" Label="Source2" />
-                  <Edge From="7" To="8" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>PupilDecodedFrames</Name>
-            </Expression>
-            <Expression xsi:type="rx:Condition">
-              <Name>DropNull</Name>
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="WorkflowInput">
-                    <Name>Source1</Name>
-                  </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>Value</Selector>
-                  </Expression>
-                  <Expression xsi:type="scr:ExpressionTransform">
-                    <scr:Expression>it == null</scr:Expression>
-                  </Expression>
-                  <Expression xsi:type="BitwiseNot" />
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="1" Label="Source1" />
-                  <Edge From="1" To="2" Label="Source1" />
-                  <Edge From="2" To="3" Label="Source1" />
-                  <Edge From="3" To="4" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>Seconds</Selector>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="IntProperty">
-                <Value>1</Value>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Zip" />
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="harp:CreateTimestamped" />
-            </Expression>
-            <Expression xsi:type="harp:Format">
-              <harp:MessageType>Event</harp:MessageType>
-              <harp:Register xsi:type="harp:FormatMessagePayload">
-                <harp:Address>300</harp:Address>
-                <harp:PayloadType>TimestampedU64</harp:PayloadType>
-              </harp:Register>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>HarpSoftwareLogging</Name>
-            </Expression>
-            <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Tuple(sys:String,p3:NetMQMessage)">
+            <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Tuple(sys:String,p2:NetMQMessage)">
               <rx:Name>OmniceptGlia</rx:Name>
             </Expression>
             <Expression xsi:type="rx:GroupBy">
@@ -354,7 +174,7 @@
               <StartIndex>0</StartIndex>
               <ExpectedIndices>3</ExpectedIndices>
             </Expression>
-            <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Tuple(sys:String,p3:NetMQMessage)">
+            <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Tuple(sys:String,p2:NetMQMessage)">
               <rx:Name>VRTransform</rx:Name>
             </Expression>
             <Expression xsi:type="rx:GroupBy">
@@ -366,7 +186,19 @@
               <StartIndex>0</StartIndex>
               <ExpectedIndices>3</ExpectedIndices>
             </Expression>
-            <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Tuple(p2:IplImage,sys:Tuple(sys:String,p3:NetMQMessage))">
+            <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Tuple(sys:String,p2:NetMQMessage)">
+              <rx:Name>UnityRecorderStatus</rx:Name>
+            </Expression>
+            <Expression xsi:type="rx:GroupBy">
+              <rx:KeySelector>Item1</rx:KeySelector>
+              <rx:ElementSelector>Item2</rx:ElementSelector>
+            </Expression>
+            <Expression xsi:type="IncludeWorkflow" Path="Extensions\ZeroMQLogging.bonsai">
+              <LogName>UnityRecorder</LogName>
+              <StartIndex>0</StartIndex>
+              <ExpectedIndices>3</ExpectedIndices>
+            </Expression>
+            <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Tuple(p3:IplImage,sys:Tuple(sys:String,p2:NetMQMessage))">
               <rx:Name>VRImage</rx:Name>
             </Expression>
             <Expression xsi:type="MemberSelector">
@@ -448,32 +280,13 @@
             <Edge From="11" To="12" Label="Source1" />
             <Edge From="13" To="14" Label="Source1" />
             <Edge From="15" To="16" Label="Source1" />
-            <Edge From="17" To="18" Label="Source1" />
+            <Edge From="16" To="17" Label="Source1" />
+            <Edge From="18" To="19" Label="Source1" />
             <Edge From="19" To="20" Label="Source1" />
             <Edge From="21" To="22" Label="Source1" />
-            <Edge From="21" To="23" Label="Source1" />
-            <Edge From="22" To="24" Label="Source1" />
-            <Edge From="23" To="24" Label="Source2" />
+            <Edge From="22" To="23" Label="Source1" />
             <Edge From="24" To="25" Label="Source1" />
             <Edge From="25" To="26" Label="Source1" />
-            <Edge From="26" To="27" Label="Source1" />
-            <Edge From="28" To="29" Label="Source1" />
-            <Edge From="29" To="30" Label="Source1" />
-            <Edge From="30" To="31" Label="Source1" />
-            <Edge From="32" To="33" Label="Source1" />
-            <Edge From="33" To="34" Label="Source1" />
-            <Edge From="34" To="35" Label="Source1" />
-            <Edge From="34" To="36" Label="Source2" />
-            <Edge From="35" To="36" Label="Source1" />
-            <Edge From="36" To="37" Label="Source1" />
-            <Edge From="37" To="38" Label="Source1" />
-            <Edge From="38" To="39" Label="Source1" />
-            <Edge From="40" To="41" Label="Source1" />
-            <Edge From="41" To="42" Label="Source1" />
-            <Edge From="43" To="44" Label="Source1" />
-            <Edge From="44" To="45" Label="Source1" />
-            <Edge From="46" To="47" Label="Source1" />
-            <Edge From="47" To="48" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
@@ -491,17 +304,10 @@
               <Lower>8</Lower>
               <Upper>16</Upper>
             </Expression>
-            <Expression xsi:type="IncludeWorkflow" Path="Extensions\Microphone.bonsai" />
-            <Expression xsi:type="IncludeWorkflow" Path="Extensions\TinkerForge.bonsai" />
-            <Expression xsi:type="IncludeWorkflow" Path="Extensions\Pupil.bonsai">
-              <Path>..\LocalPackages\FFMPEGlib</Path>
-            </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="Extensions\AdaFruitAcc.bonsai">
               <PortName>COM16</PortName>
             </Expression>
-            <Expression xsi:type="IncludeWorkflow" Path="Extensions\UBX.bonsai" />
             <Expression xsi:type="IncludeWorkflow" Path="Extensions\Empatica.bonsai" />
-            <Expression xsi:type="IncludeWorkflow" Path="Extensions\Wind.bonsai" />
             <Expression xsi:type="IncludeWorkflow" Path="Extensions\EEG.bonsai" />
             <Expression xsi:type="GroupWorkflow">
               <Name>Omnicept</Name>
@@ -1260,19 +1066,54 @@
                   <Expression xsi:type="MulticastSubject">
                     <Name>HarpSoftwareLogging</Name>
                   </Expression>
+                  <Expression xsi:type="Disable">
+                    <Builder xsi:type="Combinator">
+                      <Combinator xsi:type="zmq:Subscriber">
+                        <zmq:ConnectionString>tcp://localhost:5559</zmq:ConnectionString>
+                      </Combinator>
+                    </Builder>
+                  </Expression>
+                  <Expression xsi:type="Disable">
+                    <Builder xsi:type="IncludeWorkflow" Path="Extensions\ScreenCapture.bonsai">
+                      <Name>VRImage</Name>
+                      <CaptureRegion>
+                        <X>486</X>
+                        <Y>117</Y>
+                        <Width>624</Width>
+                        <Height>459</Height>
+                      </CaptureRegion>
+                    </Builder>
+                  </Expression>
+                  <Expression xsi:type="Disable">
+                    <Builder xsi:type="Combinator">
+                      <Combinator xsi:type="p1:UnityTimestampMicroSeconds" />
+                    </Builder>
+                  </Expression>
+                  <Expression xsi:type="Disable">
+                    <Builder xsi:type="IncludeWorkflow" Path="Extensions\TimestampExt.bonsai" />
+                  </Expression>
+                  <Expression xsi:type="Disable">
+                    <Builder xsi:type="harp:Format">
+                      <harp:MessageType>Event</harp:MessageType>
+                      <harp:Register xsi:type="harp:FormatMessagePayload">
+                        <harp:Address>220</harp:Address>
+                        <harp:PayloadType>TimestampedU64</harp:PayloadType>
+                      </harp:Register>
+                    </Builder>
+                  </Expression>
+                  <Expression xsi:type="Disable">
+                    <Builder xsi:type="MulticastSubject">
+                      <Name>HarpSoftwareLogging</Name>
+                    </Builder>
+                  </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="zmq:Subscriber">
-                      <zmq:ConnectionString>tcp://localhost:5559</zmq:ConnectionString>
+                      <zmq:ConnectionString>tcp://localhost:5561</zmq:ConnectionString>
+                      <zmq:Topic>RecordingStatus</zmq:Topic>
                     </Combinator>
                   </Expression>
-                  <Expression xsi:type="IncludeWorkflow" Path="Extensions\ScreenCapture.bonsai">
-                    <Name>VRImage</Name>
-                    <CaptureRegion>
-                      <X>486</X>
-                      <Y>117</Y>
-                      <Width>624</Width>
-                      <Height>459</Height>
-                    </CaptureRegion>
+                  <Expression xsi:type="IncludeWorkflow" Path="Extensions\ZeroMqStreamPublisher.bonsai">
+                    <Name>UnityRecorderStatus</Name>
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="p1:UnityTimestampMicroSeconds" />
@@ -1281,7 +1122,7 @@
                   <Expression xsi:type="harp:Format">
                     <harp:MessageType>Event</harp:MessageType>
                     <harp:Register xsi:type="harp:FormatMessagePayload">
-                      <harp:Address>220</harp:Address>
+                      <harp:Address>199</harp:Address>
                       <harp:PayloadType>TimestampedU64</harp:PayloadType>
                     </harp:Register>
                   </Expression>
@@ -1300,6 +1141,11 @@
                   <Edge From="8" To="9" Label="Source1" />
                   <Edge From="9" To="10" Label="Source1" />
                   <Edge From="10" To="11" Label="Source1" />
+                  <Edge From="12" To="13" Label="Source1" />
+                  <Edge From="13" To="14" Label="Source1" />
+                  <Edge From="14" To="15" Label="Source1" />
+                  <Edge From="15" To="16" Label="Source1" />
+                  <Edge From="16" To="17" Label="Source1" />
                 </Edges>
               </Workflow>
             </Expression>
@@ -1820,10 +1666,17 @@
             <Expression xsi:type="SubscribeSubject">
               <Name>LoggingPath</Name>
             </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>VRTransform</Name>
+            </Expression>
             <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Timer">
+              <Combinator xsi:type="rx:Take">
+                <rx:Count>1</rx:Count>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Delay">
                 <rx:DueTime>PT1S</rx:DueTime>
-                <rx:Period>PT0S</rx:Period>
               </Combinator>
             </Expression>
             <Expression xsi:type="Combinator">
@@ -1838,10 +1691,12 @@
             <Expression xsi:type="WorkflowOutput" />
           </Nodes>
           <Edges>
-            <Edge From="0" To="2" Label="Source1" />
-            <Edge From="1" To="2" Label="Source2" />
+            <Edge From="0" To="4" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
             <Edge From="2" To="3" Label="Source1" />
-            <Edge From="3" To="4" Label="Source1" />
+            <Edge From="3" To="4" Label="Source2" />
+            <Edge From="4" To="5" Label="Source1" />
+            <Edge From="5" To="6" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>


### PR DESCRIPTION
This PR does:
1. Cleans ExperimentAcquisitionVR workflow removing acquisition and logging nodes for: Microphone; PupilLabs; UBX, TinkerForge and Wind sensors.
2. Adds unity recording events sent from unity and logged in bonsai, making a experimental protocol for video recordings inside unity.
3. Updates UnityScreenRecording.cs unity behavior to receive a path from bonsai in order to store videos in the acquisition folder (if bonsai is not connected saves them on the unity predefined folder).
4. Update ExperimentAcquisitionVR to record experimental protocol with regular zeromq logging UnityRecorder. 
5. Add a new harp stream with unity recording events (timestamps from unity) in stream 199.

Fixes #54 
Fixes 