### PR TITLE
Normalize casing of word georeference

### DIFF
--- a/VR-Alfama/Assets/Scenes/RoundTripTest.unity
+++ b/VR-Alfama/Assets/Scenes/RoundTripTest.unity
@@ -12993,7 +12993,7 @@ GameObject:
   - component: {fileID: 1009196413}
   - component: {fileID: 1009196412}
   m_Layer: 0
-  m_Name: GeoReferencePoint2
+  m_Name: GeoreferencePoint2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -27892,7 +27892,7 @@ GameObject:
   - component: {fileID: 2016496830}
   - component: {fileID: 2016496829}
   m_Layer: 0
-  m_Name: GeoReferencePoint1
+  m_Name: GeoreferencePoint1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/VR-Alfama/Assets/Scenes/VR-Alfama.unity
+++ b/VR-Alfama/Assets/Scenes/VR-Alfama.unity
@@ -8121,7 +8121,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   PublisherBindAddress: tcp://localhost:6000
-  GeoReference:
+  Georeference:
   - Target: {fileID: 1872293744}
     Latitude: 38.714523
     Longitude: -9.131158

--- a/VR-Alfama/Assets/Scripts/TrialSession.cs
+++ b/VR-Alfama/Assets/Scripts/TrialSession.cs
@@ -25,7 +25,7 @@ public class TrialSession : DataPublisher
     }
     
     [System.Serializable]
-    public struct GeoReferenceObject
+    public struct GeoreferenceObject
     {
         public GameObject Target;
         public double Latitude;
@@ -34,7 +34,7 @@ public class TrialSession : DataPublisher
     }
 
 
-    public GeoReferenceObject[] GeoReference;
+    public GeoreferenceObject[] Georeference;
     public enum SceneType { Adverse, Optimistic }
 
     public float SecondsInterTrialInterval = 3;
@@ -84,7 +84,7 @@ public class TrialSession : DataPublisher
         //while (!InteractionSource.RightInteractionState) { yield return null; }
         yield return new WaitForSeconds(5);
         LogSession(0);
-        LogGeoReference();
+        LogGeoreference();
         UiManager.CloseMessagePanel();
 
         foreach (Trial currentTrial in TrialList)
@@ -181,9 +181,9 @@ public class TrialSession : DataPublisher
         yield return null;
     }
 
-    private void LogGeoReference()
+    private void LogGeoreference()
     {
-        foreach (var target in GeoReference)
+        foreach (var target in Georeference)
         {
             /*
              [Transform.Position.X,

--- a/Workflows/ExperimentAcquisitionVR.bonsai
+++ b/Workflows/ExperimentAcquisitionVR.bonsai
@@ -374,7 +374,7 @@
                     <ExpectedIndices>3</ExpectedIndices>
                   </Expression>
                   <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Tuple(sys:String,p2:NetMQMessage)">
-                    <rx:Name>GeoReference</rx:Name>
+                    <rx:Name>Georeference</rx:Name>
                   </Expression>
                   <Expression xsi:type="rx:GroupBy">
                     <rx:KeySelector>Item1</rx:KeySelector>
@@ -1513,7 +1513,7 @@
                           </Combinator>
                         </Expression>
                         <Expression xsi:type="IncludeWorkflow" Path="Extensions\ZeroMqStreamPublisher.bonsai">
-                          <Name>GeoReference</Name>
+                          <Name>Georeference</Name>
                         </Expression>
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="p1:UnityTimestampMicroSeconds" />


### PR DESCRIPTION
Following #91 I noticed the casing for the word georeference remained inconsistent across pluma analysis, ZMQ sockets and Unity scripts. This PR rectifies all uses of `GeoReference` to use `Georeference` instead for consistency with common uses of the term [1](https://en.wikipedia.org/wiki/Georeferencing) [2](https://support.esri.com/en-us/gis-dictionary/georeferencing)